### PR TITLE
setup.py

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,60 @@
+#####=== Python ===#####
+
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+env/
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+*.egg-info/
+.installed.cfg
+*.egg
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*,cover
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python
+
+import setuptools
+
+if __name__ == "__main__":
+    setuptools.setup(
+        name='pykernels',
+        version='0.0.4',
+
+        description='Python library for working with kernel methods in machine learning',
+        author='Wojciech Marian Czarnecki and Katarzyna Janocha',
+        author_email='wojciech.czarnecki@uj.edu.pl',
+        url='https://github.com/gmum/pykernels',
+
+        license='MIT',
+        packages=setuptools.find_packages(),
+
+        install_requires=[
+            'numpy',
+            'scipy',
+            'scikit-learn',
+        ],
+
+        classifiers=[
+            'Development Status :: 4 - Beta',
+            'Intended Audience :: Telecommunications Industry',
+            'Intended Audience :: Science/Research',
+            'License :: OSI Approved :: MIT License',
+            'Programming Language :: Python :: 2.7',
+            'Programming Language :: Python :: 3',
+            'Topic :: Multimedia :: Sound/Audio :: Analysis',
+            'Topic :: Multimedia :: Sound/Audio :: Sound Synthesis'
+        ],
+
+        zip_safe=True,
+        include_package_data=True,
+    )


### PR DESCRIPTION
As can be seen from [this StackOverflow question](https://stackoverflow.com/questions/37482104/unable-to-install-python-library-from-github) people are a bit confused as how to install your library.

Even if you don't want to publish your library on PyPI having a `setup.py` is still recommended so that people can conveniently install the library using

    pip install git+https://github.com/gmum/pykernels.git

afterwards you can simply do the usual

    from pykernels.basic import RBF

or whatever you need. No manual copying of files needed.

This pull request contains a simple `setup.py` file as well as a [generic Python `.gitignore` file](https://github.com/github/gitignore/blob/master/Python.gitignore).